### PR TITLE
Handle web search action in browser

### DIFF
--- a/patches/0087-Handle-web-search-action-in-browser.patch
+++ b/patches/0087-Handle-web-search-action-in-browser.patch
@@ -4,22 +4,22 @@ Date: Tue, 12 Jul 2022 11:16:46 +0000
 Subject: [PATCH] Handle web search action in browser
 
 ---
- .../java/src/org/chromium/base/PackageManagerUtils.java  | 9 +++++++++
+ .../java/src/org/chromium/base/PackageManagerUtils.java  | 10 ++++++++++
  chrome/android/java/AndroidManifest.xml                  | 4 ++++
  .../src/org/chromium/chrome/browser/IntentHandler.java   | 1 +
- .../chromium/chrome/browser/LaunchIntentDispatcher.java  | 4 +++-
+ .../chromium/chrome/browser/LaunchIntentDispatcher.java  | 3 ++-
  4 files changed, 17 insertions(+), 1 deletion(-)
 
 diff --git a/base/android/java/src/org/chromium/base/PackageManagerUtils.java b/base/android/java/src/org/chromium/base/PackageManagerUtils.java
 index 7aa7921e6ec3f..8fef2b2498392 100644
 --- a/base/android/java/src/org/chromium/base/PackageManagerUtils.java
 +++ b/base/android/java/src/org/chromium/base/PackageManagerUtils.java
-@@ -27,6 +27,15 @@ public class PackageManagerUtils {
+@@ -27,6 +27,16 @@ public class PackageManagerUtils {
                                                          .addCategory(Intent.CATEGORY_BROWSABLE)
                                                          .setData(Uri.fromParts("http", "", null));
  
-+    public static boolean canSelfHandleIntentActivities(Intent intent, int flags) {
-+        for (ResolveInfo ri: queryIntentActivities(intent, flags)) {
++    public static boolean canSelfHandleIntentActivities(Intent intent) {
++        for (ResolveInfo ri: queryIntentActivities(intent, PackageManager.GET_RESOLVED_FILTER)) {
 +            if (ContextUtils.getApplicationContext()
 +                    .getPackageName().equals(ri.activityInfo.packageName)) {
 +                return true;
@@ -27,6 +27,7 @@ index 7aa7921e6ec3f..8fef2b2498392 100644
 +        }
 +        return false;
 +    }
++
      /**
       * Retrieve information about the Activity that will handle the given Intent.
       *
@@ -61,14 +62,13 @@ diff --git a/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDis
 index 201336c0ba778..a9b8f0420c771 100644
 --- a/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
 +++ b/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
-@@ -213,7 +213,9 @@ public class LaunchIntentDispatcher implements IntentHandler.IntentHandlerDelega
+@@ -213,7 +213,8 @@ public class LaunchIntentDispatcher implements IntentHandler.IntentHandlerDelega
                      PackageManagerUtils
                              .queryIntentActivities(searchIntent, PackageManager.GET_RESOLVED_FILTER)
                              .size();
 -            if (resolvers == 0) {
 +            if (resolvers == 0
-+                    || PackageManagerUtils.canSelfHandleIntentActivities(searchIntent,
-+                            PackageManager.GET_RESOLVED_FILTER)) {
++                    || PackageManagerUtils.canSelfHandleIntentActivities(searchIntent)) {
                  // Phone doesn't have a WEB_SEARCH action handler, open Search Activity with
                  // the given query.
                  Intent searchActivityIntent = new Intent(Intent.ACTION_MAIN);

--- a/patches/0087-Handle-web-search-action-in-browser.patch
+++ b/patches/0087-Handle-web-search-action-in-browser.patch
@@ -1,0 +1,74 @@
+From 8ee91d6b5e701e3b5e6228451d314002225a5477 Mon Sep 17 00:00:00 2001
+From: quh4gko8 <88831734+quh4gko8@users.noreply.github.com>
+Date: Tue, 12 Jul 2022 11:16:46 +0000
+Subject: [PATCH] Handle web search action in browser
+
+---
+ .../java/src/org/chromium/base/PackageManagerUtils.java  | 9 +++++++++
+ chrome/android/java/AndroidManifest.xml                  | 4 ++++
+ .../src/org/chromium/chrome/browser/IntentHandler.java   | 1 +
+ .../chromium/chrome/browser/LaunchIntentDispatcher.java  | 4 +++-
+ 4 files changed, 17 insertions(+), 1 deletion(-)
+
+diff --git a/base/android/java/src/org/chromium/base/PackageManagerUtils.java b/base/android/java/src/org/chromium/base/PackageManagerUtils.java
+index 7aa7921e6ec3f..8fef2b2498392 100644
+--- a/base/android/java/src/org/chromium/base/PackageManagerUtils.java
++++ b/base/android/java/src/org/chromium/base/PackageManagerUtils.java
+@@ -27,6 +27,15 @@ public class PackageManagerUtils {
+                                                         .addCategory(Intent.CATEGORY_BROWSABLE)
+                                                         .setData(Uri.fromParts("http", "", null));
+ 
++    public static boolean canSelfHandleIntentActivities(Intent intent, int flags) {
++        for (ResolveInfo ri: queryIntentActivities(intent, flags)) {
++            if (ContextUtils.getApplicationContext()
++                    .getPackageName().equals(ri.activityInfo.packageName)) {
++                return true;
++            }
++        }
++        return false;
++    }
+     /**
+      * Retrieve information about the Activity that will handle the given Intent.
+      *
+diff --git a/chrome/android/java/AndroidManifest.xml b/chrome/android/java/AndroidManifest.xml
+index 8cf03aa889ddf..020301f2fa53a 100644
+--- a/chrome/android/java/AndroidManifest.xml
++++ b/chrome/android/java/AndroidManifest.xml
+@@ -324,6 +324,10 @@ by a child template that "extends" this file.
+             <intent-filter>
+                 <action android:name="android.intent.action.SEARCH" />
+             </intent-filter>
++            <intent-filter>  # DOWNSTREAM
++              <action android:name="android.intent.action.WEB_SEARCH"/>
++              <category android:name="android.intent.category.DEFAULT" />
++            </intent-filter>  # DOWNSTREAM
+             <intent-filter>
+                 <action android:name="com.sec.android.airview.HOVER" />
+             </intent-filter>
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/IntentHandler.java b/chrome/android/java/src/org/chromium/chrome/browser/IntentHandler.java
+index d9aa774f861b3..be7a3764ffb2f 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/IntentHandler.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/IntentHandler.java
+@@ -718,6 +718,7 @@ public class IntentHandler {
+         String query = null;
+         final String action = intent.getAction();
+         if (Intent.ACTION_SEARCH.equals(action)
++                || Intent.ACTION_WEB_SEARCH.equals(action)
+                 || MediaStore.INTENT_ACTION_MEDIA_SEARCH.equals(action)) {
+             query = IntentUtils.safeGetStringExtra(intent, SearchManager.QUERY);
+         }
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java b/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
+index 201336c0ba778..a9b8f0420c771 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/LaunchIntentDispatcher.java
+@@ -213,7 +213,9 @@ public class LaunchIntentDispatcher implements IntentHandler.IntentHandlerDelega
+                     PackageManagerUtils
+                             .queryIntentActivities(searchIntent, PackageManager.GET_RESOLVED_FILTER)
+                             .size();
+-            if (resolvers == 0) {
++            if (resolvers == 0
++                    || PackageManagerUtils.canSelfHandleIntentActivities(searchIntent,
++                            PackageManager.GET_RESOLVED_FILTER)) {
+                 // Phone doesn't have a WEB_SEARCH action handler, open Search Activity with
+                 // the given query.
+                 Intent searchActivityIntent = new Intent(Intent.ACTION_MAIN);


### PR DESCRIPTION
Use existing intent handling to redirect to its own SearchActivity if opened by external app.